### PR TITLE
Set node version to up 9.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "burn",
   "version": "0.0.1",
   "private": true,
+  "engines": {
+    "node": ">=9.10.0"
+  },
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "ios": "cd ios && open burn.xcodeproj",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "engines": {
-    "node": ">=9.10.0"
+    "node": "8.12.0"
   },
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
```
error eslint@5.6.0: The engine "node" is incompatible with this module. Expected version "^6.14.0 || ^8.10.0 || >=9.10.0".
```

Just to make more clear that the node version should be >= 9.10.0